### PR TITLE
Supporting *any* feed API

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,54 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
     <script src="src/jquery.rss.js"></script>
     <script>
+
       jQuery(function($) {
-        $("#rss-feeds").rss("http://feeds.feedburner.com/dawanda", {
+        $("#rss-feeds").rss("http://blog.superfeedr.com/atom.xml", {
+          ssl: true,
+          host: 'push.superfeedr.com',
           limit: 15,
-          effect: 'slideFastSynced'
+          buildUrl: function(rss) {
+            var auth = btoa(['superfeedr', 'c77d4103dfe9fe2f32b19b9b4653c09b'].join(':'));
+            var apiProtocol = 'http' + (rss.options.ssl ? 's' : '');
+            var apiHost     = apiProtocol + '://' + rss.options.host;
+            var apiUrl      = apiHost + '?';
+            apiUrl += 'callback=?';
+            apiUrl += '&count=' + rss.options.limit || 10;
+            apiUrl += '&format=json';
+            apiUrl += '&hub.mode=retrieve';
+            apiUrl += '&hub.topic=' + encodeURIComponent(rss.url);
+            apiUrl += '&authorization=' + auth;
+
+            return apiUrl;
+          },
+          transform: function transform(data) {
+            var x = {
+              responseData: {
+                feed: {
+                  feedUrl: data.status.feed,
+                  title: data.title,
+                  link: '',
+                  description: '',
+                  author: '',
+                  entries: []
+                }
+              }
+            };
+
+            data.items.forEach(function(i) {
+              x.responseData.feed.entries.push({
+                title: i.title,
+                link: i.permalinkUrl,
+                content: i.content,
+                contentSnippet: i.summary || i.content,
+                publishedDate: new Date(1000 * i.published).toISOString(),
+                categories: i.categories || [],
+                author: i.actor.displayName
+              });
+            })
+
+            return x;
+          }
         })
       })
     </script>

--- a/src/jquery.rss.js
+++ b/src/jquery.rss.js
@@ -50,21 +50,27 @@
   ];
 
   RSS.prototype.load = function (callback) {
-    var apiProtocol = 'http' + (this.options.ssl ? 's' : '');
-    var apiHost     = apiProtocol + '://' + this.options.host;
-    var apiUrl      = apiHost + '?callback=?&q=' + encodeURIComponent(this.url);
-
-    // set limit to offsetEnd if offset has been set
-    if (this.options.offsetStart && this.options.offsetEnd) {
-      this.options.limit = this.options.offsetEnd;
+    var apiUrl = '';
+    if(typeof(this.options.buildUrl) == 'function' ) {
+      apiUrl = this.options.buildUrl(this);
     }
+    else {
+      var apiProtocol = 'http' + (this.options.ssl ? 's' : '');
+      var apiHost     = apiProtocol + '://' + this.options.host;
+      var apiUrl      = apiHost + '?callback=?&q=' + encodeURIComponent(this.url);
 
-    if (this.options.limit !== null) {
-      apiUrl += '&num=' + this.options.limit;
-    }
+      // set limit to offsetEnd if offset has been set
+      if (this.options.offsetStart && this.options.offsetEnd) {
+        this.options.limit = this.options.offsetEnd;
+      }
 
-    if (this.options.key !== null) {
-      apiUrl += '&key=' + this.options.key;
+      if (this.options.limit !== null) {
+        apiUrl += '&num=' + this.options.limit;
+      }
+
+      if (this.options.key !== null) {
+        apiUrl += '&key=' + this.options.key;
+      }
     }
 
     $.getJSON(apiUrl, callback);
@@ -74,6 +80,11 @@
     var self = this;
 
     this.load(function (data) {
+      if(typeof(self.options.transform) == 'function')
+        data = self.options.transform(data);
+
+      window.lastX = data;
+
       try {
         self.feed    = data.responseData.feed;
         self.entries = data.responseData.feed.entries;


### PR DESCRIPTION
Hey... this is probably not ready to be merged but I wanted to show you a POC of how you could easily support any feed API.
The *trick* is to provide 2 optional functions in the options:
* `buildUrl` which lets the user build the URL they want to talk with the service they need. 
* `transform` which transforms the services's response into something intelligible for this plugin

This is a simple "adapter" pattern and it would be great if something similar landed in jquery-rss :)
It's what I described in #68 